### PR TITLE
update http.zig to fix zig master 0.14.0-dev.3026+c225b780e

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "2.0.0",
     .dependencies = .{
         .httpz = .{
-            .url = "git+https://github.com/karlseguin/http.zig?ref=master#8debcdedbc91481610dff2fa3313851e5f3b8e4b",
-            .hash = "1220e384f2067b5343ee176d858a78ec8268e1aef12307d6af79f25e1a9a0dcbe1f3",
+            .url = "git+https://github.com/karlseguin/http.zig?ref=master#a691d731047e9a5a79d71ac594cb8f5fad1d0705",
+            .hash = "122072c92285c8c44055eb45058b834d1e7ecd46a5704d58a207103c39fb5922b8f5",
         },
     },
     .paths = .{


### PR DESCRIPTION
There is a small change(https://github.com/ziglang/zig/pull/22627) in the latest zig version for the function (I’m testing it with 0.14.0-dev.3026+c225b780e) and it won’t compile anymore.std.posix.clock_gettime.