### PR TITLE
fix examples ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,8 @@ jobs:
 
               zig build
               ./zig-out/bin/$example &
+              SERVER_PID=$!
+              
               timeout=15
               while ! nc -z 127.0.0.1 8080; do
                   echo "Waiting for server..."
@@ -53,8 +55,7 @@ jobs:
               HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" $URL || echo "failed")
 
               echo "Killing process for $example..."
-              kill `ps -ef| grep -i $example | grep -v grep | awk '{print $2}'`
-              sleep 3
+              kill -TERM $SERVER_PID 2>/dev/null || true
 
               # Check the result
               if [[ "$HTTP_STATUS" == "200" ]]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
               cd "$EXAMPLE_DIR"
 
               zig build
-              zig build run &
+              ./zig-out/bin/$example &
               timeout=15
               while ! nc -z 127.0.0.1 8080; do
                   echo "Waiting for server..."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
                   sleep 1
                   timeout=$((timeout - 1))
                   if [ $timeout -le 0 ]; then
-                      echo "$EXAMPLE_DIR did not start within $timeout seconds."
+                      echo "$EXAMPLE_DIR did not start within 15 seconds."
                       exit 1
                   fi
               done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
               HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" $URL || echo "failed")
 
               echo "Killing process for $example..."
-              pkill $example
+              kill `ps -ef| grep -i $example | grep -v grep | awk '{print $2}'`
               sleep 3
 
               # Check the result

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
               HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" $URL || echo "failed")
 
               echo "Killing process for $example..."
-              pkill zig
+              pkill $example
               sleep 3
 
               # Check the result

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           ROOT_DIR=$(pwd)
           for example in {hello,hello_app,blog,todos_orm_sqlite}; do
               EXAMPLE_DIR="$ROOT_DIR/examples/$example/"
-              echo "Testing $EXAMPLE_DIR"
+              echo "Testing $example"
               cd "$EXAMPLE_DIR"
 
               zig build
@@ -58,9 +58,9 @@ jobs:
 
               # Check the result
               if [[ "$HTTP_STATUS" == "200" ]]; then
-                  echo "$EXAMPLE_DIR: OK"
+                  echo "$example: OK"
               else
-                  echo "$EXAMPLE_DIR: Failed with status $HTTP_STATUS"
+                  echo "$example: Failed with status $HTTP_STATUS"
                   exit 1
               fi
           done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
               HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" $URL || echo "failed")
 
               echo "Killing process for $example..."
-              kill `ps -ef| grep -i $example | grep -v grep | awk '{print $2}'`
+              pkill zig
               sleep 3
 
               # Check the result

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       
       - name: Check examples
         run: |
-         ROOT_DIR=$(pwd)
+          ROOT_DIR=$(pwd)
           for example in {hello,hello_app,blog,todos_orm_sqlite}; do
               EXAMPLE_DIR="$ROOT_DIR/examples/$example/"
               echo "Testing $EXAMPLE_DIR"
@@ -34,9 +34,15 @@ jobs:
 
               zig build
               zig build run &
-              until nc -z localhost 8080; do
+              timeout=15
+              while ! nc -z 127.0.0.1 8080; do
                   echo "Waiting for server..."
                   sleep 1
+                  timeout=$((timeout - 1))
+                  if [ $timeout -le 0 ]; then
+                      echo "$EXAMPLE_DIR did not start within $timeout seconds."
+                      exit 1
+                  fi
               done
 
               URL="http://127.0.0.1:8080"
@@ -58,3 +64,4 @@ jobs:
                   exit 1
               fi
           done
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,27 +26,35 @@ jobs:
       
       - name: Check examples
         run: |
-          ROOT_DIR=$(pwd)
-          for example_dir in examples/{hello,hello_app,blog,todos_orm_sqlite}/; do
-            echo "Testing $example_dir"
-            cd "$ROOT_DIR/$example_dir"
-            zig build
-            zig build run &
-            SERVER_PID=$!
-            sleep 3
+         ROOT_DIR=$(pwd)
+          for example in {hello,hello_app,blog,todos_orm_sqlite}; do
+              EXAMPLE_DIR="$ROOT_DIR/examples/$example/"
+              echo "Testing $EXAMPLE_DIR"
+              cd "$EXAMPLE_DIR"
 
-            URL=http://127.0.0.1:8080
-            if [[ "$example_dir" == "examples/todos_orm_sqlite/" ]]; then
-                URL="http://127.0.0.1:8080/todo"
-            fi
-            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" $URL || echo "failed")
-            kill -TERM $SERVER_PID 2>/dev/null || true
-            
-            # Check the result
-            if [[ "$HTTP_STATUS" == "200" ]]; then
-              echo "$example_dir: OK"
-            else
-              echo "$example_dir: Failed with status $HTTP_STATUS"
-              exit 1
-            fi
+              zig build
+              zig build run &
+              until nc -z localhost 8080; do
+                  echo "Waiting for server..."
+                  sleep 1
+              done
+
+              URL="http://127.0.0.1:8080"
+              if [[ "$example" == "todos_orm_sqlite" ]]; then
+                  URL="http://127.0.0.1:8080/todo"
+              fi
+              echo "GET $URL"
+              HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" $URL || echo "failed")
+
+              echo "Killing process for $example..."
+              kill `ps -ef| grep -i $example | grep -v grep | awk '{print $2}'`
+              sleep 3
+
+              # Check the result
+              if [[ "$HTTP_STATUS" == "200" ]]; then
+                  echo "$EXAMPLE_DIR: OK"
+              else
+                  echo "$EXAMPLE_DIR: Failed with status $HTTP_STATUS"
+                  exit 1
+              fi
           done

--- a/examples/blog/build.zig
+++ b/examples/blog/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const exe = b.addExecutable(.{
-        .name = "example",
+        .name = "blog",
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,

--- a/examples/blog/build.zig.zon
+++ b/examples/blog/build.zig.zon
@@ -1,6 +1,6 @@
 .{
-    .name = .example,
-    .fingerprint = 0x6eec9b9fbe88312b,
+    .name = .blog,
+    .fingerprint = 0xc0155143f78c2d6c,
     .version = "0.0.0",
     .dependencies = .{ .tokamak = .{ .path = "../.." } },
     .paths = .{


### PR DESCRIPTION
This should fix the CI for the examples, where it seems that before the processes weren't killed successfully.

It now waits for the server beeing ready using netcat and terminates it by the process name. 
Therefore the change for blog executable name from "example" to "blog", so the loop still works with the example path names.

~Not quite sure about the shutdown, I feel like it should behave differently when sending a graceful shutdown with `kill`.~
```
error: the following build command crashed:
/home/runner/.cache/zig/o/44ce052ee8894cab1b2a3c4f6fb2a880/build /opt/hostedtoolcache/zig/0.14.0/x64/zig /opt/hostedtoolcache/zig/0.14.0/x64/lib /home/runner/work/tokamak/tokamak/examples/todos_orm_sqlite /home/runner/.cache/zig /home/runner/.cache/zig --seed 0xd93e7433 -Z0dc84b1bf9601e36 run
```
edit: seems fine now when directly executing the bin instead of `zig build run`

Dont know if this is perfect, but it seems to work reliably (I ran it multiple times).
https://github.com/saicu/tokamak/actions/runs/14839781065/job/41659689278
